### PR TITLE
Add github tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Test
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        meteorRelease:
+          - '--release 1.4.4.5'
+          - '--release 1.5.4.1'
+          - '--release 1.6.0.1'
+          - '--release 1.7.0.5'
+          - '--release 1.8.1'
+          - '--release 1.8.3'
+          - '--release 1.9.1'
+          - '--release 1.10.2'
+          - '--release 1.11'
+          - '--release 1.12.1'
+          - '--release 2.1.1'
+          - '--release 2.2'
+          - '--release 2.3.2'
+          # Latest version
+          - 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+
+      - name: Install Dependencies
+        run: |
+          curl https://install.meteor.com | /bin/sh
+          npm i -g @zodern/mtest
+
+      - name: Run Tests
+        run: |
+          # Retry tests since some of them are flaky
+          mtest --package ./ --once ${{ matrix.meteorRelease }} || mtest --package ./ --once ${{ matrix.meteorRelease }} 


### PR DESCRIPTION
It has been a while but I never forgot :sweat_smile:
Applying the same testing scheme from [collection2](https://github.com/Meteor-Community-Packages/meteor-collection2/blob/master/.github/workflows/testsuite.yml) wouldn't work because the tests are not invoked within a meteor app but thanks to [montiapm](https://github.com/monti-apm/monti-apm-agent/blob/master/.github/workflows/test.yml) I found out that you can invoke package tests directly without a wrapper app using [@@zodern/mtest](https://www.npmjs.com/package/@zodern/mtest) utility.